### PR TITLE
update readme

### DIFF
--- a/cluster-autoscaler/README.md
+++ b/cluster-autoscaler/README.md
@@ -25,6 +25,7 @@ Starting from Kubernetes 1.12, versioning scheme was changed to match Kubernetes
 
 | Kubernetes Version  | CA Version   |
 |--------|--------|
+| 1.16.X | 1.16.X  |
 | 1.15.X | 1.15.X  |
 | 1.14.X | 1.14.X  |
 | 1.13.X | 1.13.X  |


### PR DESCRIPTION
added to compatibility chart: | 1.16.X | 1.16.X  |

is that correct?